### PR TITLE
[MAINTENANCE] #3 - Add GitHub Action workflow to publish to crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish to crates.io
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
+
+jobs:
+  publish:
+    name: Publish crate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify version matches tag
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          CARGO_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "Error: Tag version ($TAG_VERSION) does not match Cargo.toml version ($CARGO_VERSION)"
+            exit 1
+          fi
+          echo "Version check passed: $CARGO_VERSION"
+
+      - name: Run tests
+        run: cargo test --all-features
+
+      - name: Publish to crates.io
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Closes #3

This PR adds an automated GitHub Actions workflow to publish the crate to crates.io when version tags are pushed.

**Features:**
- Triggers on both stable tags (`v*.*.*`) and pre-release tags (`v*.*.*-*`)
- Verifies that the tag version matches the version in Cargo.toml
- Runs all tests with all features before publishing
- Publishes to crates.io using `CARGO_REGISTRY_TOKEN` secret

**Note:** The `CARGO_REGISTRY_TOKEN` secret must be configured in the repository or organization settings for the workflow to successfully publish.